### PR TITLE
fix using 'nu' argument in n-d grid spline evaluator

### DIFF
--- a/tests/test_ndg.py
+++ b/tests/test_ndg.py
@@ -205,15 +205,21 @@ def test_auto_smooth_2d(ndgrid_2d_data):
     (1, 1),
     (2, 2),
 ])
-def test_evaluate_nu(nu: tuple):
+@pytest.mark.parametrize('extrapolate', [
+    None,
+    True,
+    False,
+])
+def test_evaluate_nu_extrapolate(nu: tuple, extrapolate: bool):
     x = ([1, 2, 3, 4], [1, 2, 3, 4])
+    xi = ([0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5])
     y = np.arange(4 * 4).reshape((4, 4))
 
     ss = csaps.NdGridCubicSmoothingSpline(x, y, smooth=1.0)
-    y_ss = ss(x, nu=nu)
+    y_ss = ss(xi, nu=nu, extrapolate=extrapolate)
 
     pp = NdPPoly(ss.spline.c, x)
-    xx = tuple(np.meshgrid(*x, indexing='ij'))
-    y_pp = pp(xx, nu=nu)
+    xx = tuple(np.meshgrid(*xi, indexing='ij'))
+    y_pp = pp(xx, nu=nu, extrapolate=extrapolate)
 
-    assert y_ss == pytest.approx(y_pp)
+    np.testing.assert_allclose(y_ss, y_pp, equal_nan=True)

--- a/tests/test_ndg.py
+++ b/tests/test_ndg.py
@@ -3,6 +3,7 @@
 import pytest
 
 import numpy as np
+from scipy.interpolate import NdPPoly
 import csaps
 
 
@@ -196,3 +197,22 @@ def test_auto_smooth_2d(ndgrid_2d_data):
 
     assert s.smooth == pytest.approx(smooth_expected)
     assert zi == pytest.approx(zi_expected)
+
+
+@pytest.mark.parametrize('nu', [
+    (0, 0),
+    (1, 1),
+    (2, 2),
+])
+def test_evaluate_nu(nu: tuple):
+    x = ([1, 2, 3, 4], [1, 2, 3, 4])
+    y = np.arange(4 * 4).reshape((4, 4))
+
+    ss = csaps.NdGridCubicSmoothingSpline(x, y, smooth=1.0)
+    y_ss = ss(x, nu=nu)
+
+    pp = NdPPoly(ss.spline.c, x)
+    xx = tuple(np.meshgrid(*x, indexing='ij'))
+    y_pp = pp(xx, nu=nu)
+
+    assert y_ss == pytest.approx(y_pp)

--- a/tests/test_ndg.py
+++ b/tests/test_ndg.py
@@ -200,6 +200,7 @@ def test_auto_smooth_2d(ndgrid_2d_data):
 
 
 @pytest.mark.parametrize('nu', [
+    None,
     (0, 0),
     (1, 1),
     (2, 2),

--- a/tests/test_ndg.py
+++ b/tests/test_ndg.py
@@ -222,4 +222,4 @@ def test_evaluate_nu_extrapolate(nu: tuple, extrapolate: bool):
     xx = tuple(np.meshgrid(*xi, indexing='ij'))
     y_pp = pp(xx, nu=nu, extrapolate=extrapolate)
 
-    np.testing.assert_allclose(y_ss, y_pp, equal_nan=True)
+    np.testing.assert_allclose(y_ss, y_pp, rtol=1e-05, atol=1e-08, equal_nan=True)

--- a/tests/test_umv.py
+++ b/tests/test_umv.py
@@ -244,14 +244,16 @@ def test_cubic_bc_natural():
 
 
 @pytest.mark.parametrize('nu', [0, 1, 2])
-def test_evaluate_nu(nu):
+@pytest.mark.parametrize('extrapolate', [None, True, False, 'periodic'])
+def test_evaluate_nu_extrapolate(nu, extrapolate):
     x = [1, 2, 3, 4]
+    xi = [0, 1, 2, 3, 4, 5]
     y = [1, 2, 3, 4]
 
     cs = CubicSpline(x, y)
-    y_cs = cs(x, nu=nu)
+    y_cs = cs(xi, nu=nu, extrapolate=extrapolate)
 
     ss = csaps.CubicSmoothingSpline(x, y, smooth=1.0)
-    y_ss = ss(x, nu=nu)
+    y_ss = ss(xi, nu=nu, extrapolate=extrapolate)
 
-    assert y_ss == pytest.approx(y_cs)
+    np.testing.assert_allclose(y_ss, y_cs, equal_nan=True)

--- a/tests/test_umv.py
+++ b/tests/test_umv.py
@@ -256,4 +256,4 @@ def test_evaluate_nu_extrapolate(nu, extrapolate):
     ss = csaps.CubicSmoothingSpline(x, y, smooth=1.0)
     y_ss = ss(xi, nu=nu, extrapolate=extrapolate)
 
-    np.testing.assert_allclose(y_ss, y_cs, equal_nan=True)
+    np.testing.assert_allclose(y_ss, y_cs, rtol=1e-05, atol=1e-08, equal_nan=True)

--- a/tests/test_umv.py
+++ b/tests/test_umv.py
@@ -241,3 +241,17 @@ def test_cubic_bc_natural():
 
     assert cs.c == pytest.approx(ss.spline.c)
     assert y_cs == pytest.approx(y_ss)
+
+
+@pytest.mark.parametrize('nu', [0, 1, 2])
+def test_evaluate_nu(nu):
+    x = [1, 2, 3, 4]
+    y = [1, 2, 3, 4]
+
+    cs = CubicSpline(x, y)
+    y_cs = cs(x, nu=nu)
+
+    ss = csaps.CubicSmoothingSpline(x, y, smooth=1.0)
+    y_ss = ss(x, nu=nu)
+
+    assert y_ss == pytest.approx(y_cs)


### PR DESCRIPTION
We need to pass `nu[i]` argument to PPoly 1-d evaluator